### PR TITLE
Fix SDL 60 FPS capping

### DIFF
--- a/src/Adapter/SDL/Render/FrameRateLimiter.php
+++ b/src/Adapter/SDL/Render/FrameRateLimiter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PhPresent\Adapter\SDL\Render;
+
+class FrameRateLimiter
+{
+    public function __construct(int $fps, int $minimumPause = 5)
+    {
+        $this->frameDuration = (int) (1000 / $fps);
+        $this->minimumPause = $minimumPause;
+    }
+
+    public function renderingStarts(): void
+    {
+        $this->startTime = $this->getTime();
+    }
+
+    public function pause()
+    {
+        SDL_Delay(max(
+            $this->minimumPause,
+            $this->frameDuration - ($this->getTime() - $this->startTime)
+        ));
+    }
+
+    private function getTime(): int
+    {
+        return (int) (microtime(true) * 1000);
+    }
+
+    /** @var int */
+    private $startTime;
+    /** @var int */
+    private $frameDuration;
+    /** @var int */
+    private $minimumPause;
+}


### PR DESCRIPTION
 * 60 FPS is a 1000/60ms (16.6667ms) pause between each iteration. But, since `SDL_Delay` only accepts a Uint32 as delay, 16.6667 is always casted to an int equal to 16.
 * To get as close as possible to 60 FPS, we also have to take the rendering time in consideration and substract this time to the 16ms pause duration.